### PR TITLE
use setuptools for scripts and deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ python:
   - 2.6
   - 2.7
 install:
-  - "pip install -r requirements.txt -r test_requirements.txt"
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r 2.6_requirements.txt --upgrade; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install coveralls ; fi"
+  - pip install .
+  - pip install -r test_requirements.txt
 script:
   - ./test.sh
   - nosetests test/test_file_io.py:pack_unpack_hard
   - nosetests test/test_numpy_io.py:huge_arrays
 after_success:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls ; fi"
+  - coveralls
 notifications:
   email: false

--- a/2.6_requirements.txt
+++ b/2.6_requirements.txt
@@ -1,2 +1,0 @@
-argparse
-ordereddict

--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,6 @@ dependencies and bloscpack itself:
 
 .. code-block:: console
 
-    $ wget https://raw.github.com/Blosc/bloscpack/master/requirements.txt
-    $ pip install -r requirements.txt
     $ pip install bloscpack
 
 If you want to install straight from GitHub, use pip's VCS support:
@@ -106,7 +104,6 @@ the standard ``setup.py``:
 
     $ git clone https://github.com/Blosc/bloscpack
     $ cd bloscpack
-    $ pip install -r requirements.txt
     $ python setup.py install
 
 Usage

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,40 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 
-from distutils.core import setup
+from setuptools import setup
+import sys
 
-long_description = open('README.rst').read()
+with open('README.rst') as f:
+    long_description = f.read()
 
-exec(open('bloscpack/version.py').read())
+with open('bloscpack/version.py') as f:
+    exec(f.read())
+
+install_requires = [
+    'blosc>=1.2.0',
+    'numpy'
+]
+
+if sys.version_info[:2] < (2, 7):
+    install_requires += ['ordereddict', 'argparse']
+    
+tests_require = [
+    'nose',
+    'cram>=0.6',
+    'mock',
+    'coverage',
+    'coveralls'
+]
 
 setup(
     name = "bloscpack",
     version = __version__,
     packages = ['bloscpack'],
-    scripts = ['blpk'],
+    entry_points = {
+        'console_scripts' : [
+            'blpk = bloscpack.cli:main',
+        ]
+    },
     author = "Valentin Haenel",
     author_email = "valentin@haenel.co",
     description = "Command line interface to and serialization format for Blosc",
@@ -20,12 +43,17 @@ setup(
     license = "MIT",
     keywords = ('compression', 'applied information theory'),
     url = "https://github.com/blosc/bloscpack",
+    install_requires = install_requires,
+    extras_require = dict(tests=tests_require),
+    tests_require = tests_require,
     classifiers = ['Development Status :: 3 - Alpha',
                    'Environment :: Console',
                    'License :: OSI Approved :: MIT License',
+                   'Operating System :: Microsoft :: Windows',
                    'Operating System :: POSIX',
                    'Programming Language :: Python',
                    'Topic :: Scientific/Engineering',
+                   'Topic :: System :: Archiving :: Compression',
                    'Topic :: Utilities',
                   ],
      )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ nose
 cram>=0.6
 mock
 coverage
+coveralls


### PR DESCRIPTION
* make script work on win32
* simplify install instructions
* AFAIK pip requires setuptools to be present when installing from source.