### PR TITLE
Object arrays should be rejected.

### DIFF
--- a/bloscpack/exceptions.py
+++ b/bloscpack/exceptions.py
@@ -61,3 +61,6 @@ class NotEnoughSpace(RuntimeError):
 
 class NotANumpyArray(RuntimeError):
     pass
+
+class ObjectNumpyArrayRejection(RuntimeError):
+    pass

--- a/bloscpack/numpy_io.py
+++ b/bloscpack/numpy_io.py
@@ -25,6 +25,7 @@ from .abstract_io import (PlainSource,
                           PlainSink,
                           )
 from .exceptions import (NotANumpyArray,
+                         ObjectNumpyArrayRejection,
                          )
 from . import log
 
@@ -118,7 +119,8 @@ def pack_ndarray(ndarray, sink,
     The 'typesize' value of 'blosc_args' will be silently ignored and replaced
     with the itemsize of the Numpy array's dtype.
     """
-
+    if ndarray.dtype.hasobject:
+        raise ObjectNumpyArrayRejection
     if blosc_args is None:
         blosc_args = BloscArgs(typesize=ndarray.dtype.itemsize)
     else:

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -170,6 +170,10 @@ def test_reject_object_array():
     nt.assert_raises(ObjectNumpyArrayRejection, roundtrip_numpy_memory, a)
 
 
+def test_reject_nested_object_array():
+    a = np.array([(1, 'abc'), (2, 'def'), (3, 'ghi')],
+                  dtype=[('a', int), ('b', 'object')])
+    nt.assert_raises(ObjectNumpyArrayRejection, roundtrip_numpy_memory, a)
 
 
 def test_itemsize_chunk_size_mismatch():

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -164,6 +164,11 @@ def test_numpy_dtypes_shapes_order():
         yield case
 
 
+def test_reject_object_array():
+    a = np.array([(1, 'abc'), (2, 'def'), (3, 'ghi')], dtype='object')
+    nt.assert_raises(Exception, roundtrip_ndarray, a)
+
+
 def test_itemsize_chunk_size_mismatch():
     a = np.arange(10)
     nt.assert_raises(ChunkSizeTypeSizeMismatch,

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -19,6 +19,7 @@ from bloscpack.args import (BloscArgs,
                             )
 from bloscpack.exceptions import (NotANumpyArray,
                                   ChunkSizeTypeSizeMismatch,
+                                  ObjectNumpyArrayRejection,
                                   )
 from bloscpack.file_io import (PlainFPSource,
                                CompressedFPSource,
@@ -166,7 +167,9 @@ def test_numpy_dtypes_shapes_order():
 
 def test_reject_object_array():
     a = np.array([(1, 'abc'), (2, 'def'), (3, 'ghi')], dtype='object')
-    nt.assert_raises(Exception, roundtrip_ndarray, a)
+    nt.assert_raises(ObjectNumpyArrayRejection, roundtrip_numpy_memory, a)
+
+
 
 
 def test_itemsize_chunk_size_mismatch():


### PR DESCRIPTION
See 8d17c16bb8c5618c31a0cb22281e281af036beff for reason.