### PR TITLE
Use ast.literal_eval instead of np.safe_eval which is at least 20x slower

### DIFF
--- a/bloscpack/numpy_io.py
+++ b/bloscpack/numpy_io.py
@@ -96,9 +96,6 @@ def _conv(descr):
             descr = tuple([_conv(d) for d in descr])
     elif six.PY2 and isinstance(descr, unicode):
         descr = str(descr)
-    else:
-        # keep descr as is
-        pass
     return descr
 
 

--- a/bloscpack/numpy_io.py
+++ b/bloscpack/numpy_io.py
@@ -3,6 +3,8 @@
 # vim :set ft=py:
 
 
+import ast
+
 import blosc
 import numpy
 import six
@@ -116,9 +118,9 @@ class PlainNumpySink(PlainSink):
         # them. In this case, it will raise a TypeError and the _conv function
         # above is used to convert the dtype accordingly.
         try:
-            dtype_ = numpy.safe_eval(metadata['dtype'])
-        except SyntaxError:
-            dtype_ = metadata['dtype']
+            dtype_ = ast.literal_eval(metadata['dtype'])
+        except (ValueError, SyntaxError):
+            dtype_ = _conv(metadata['dtype'])
         except TypeError:
             dtype_ = _conv(metadata['dtype'])
         self.ndarray = numpy.empty(metadata['shape'],

--- a/bloscpack/numpy_io.py
+++ b/bloscpack/numpy_io.py
@@ -121,8 +121,6 @@ class PlainNumpySink(PlainSink):
             dtype_ = ast.literal_eval(metadata['dtype'])
         except (ValueError, SyntaxError):
             dtype_ = _conv(metadata['dtype'])
-        except TypeError:
-            dtype_ = _conv(metadata['dtype'])
         self.ndarray = numpy.empty(metadata['shape'],
                                    dtype=numpy.dtype(dtype_),
                                    order=metadata['order'])


### PR DESCRIPTION
Python 3: ~78x speedup

```python
In [5]: import ast, numpy as np

In [6]: timeit ast.literal_eval('1')
The slowest run took 4.03 times longer than the fastest. This could mean that an intermediate result is being cached
100000 loops, best of 3: 4.43 µs per loop

In [7]: timeit np.safe_eval('1')
1000 loops, best of 3: 357 µs per loop
```

Python 2: ~20x speedup


```python
In [1]: import ast, numpy as np

In [2]: timeit ast.literal_eval('1')
The slowest run took 5.84 times longer than the fastest. This could mean that an intermediate result is being cached
100000 loops, best of 3: 4.29 µs per loop

In [3]: timeit np.safe_eval('1')
The slowest run took 58.04 times longer than the fastest. This could mean that an intermediate result is being cached
10000 loops, best of 3: 75.6 µs per loop
```