### PR TITLE
fancy indexing of numpy array causes error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ python:
   - 2.6
   - 2.7
   - 3.4
+  - 3.5
 install:
-  - pip install .
+  - pip install -r requirements.txt
   - pip install -r test_requirements.txt
+  - pip install .
 script:
   - ./test.sh
   - nosetests test/test_file_io.py:pack_unpack_hard

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
 script:
   - ./test.sh
   - nosetests test/test_file_io.py:pack_unpack_hard
-  - nosetests test/test_numpy_io.py:huge_arrays
 after_success:
   - coveralls
 notifications:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-blosc>=1.2.7
+blosc==1.2.7
 numpy
 six

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -221,14 +221,16 @@ def test_itemsize_chunk_size_mismatch():
 def test_larger_arrays():
     for dt in ('uint64', 'int64', 'float64'):
         a = np.arange(2e4, dtype=dt)
-        roundtrip_ndarray(a)
+        for case in roundtrip_ndarray(a):
+            yield case
 
 
 def huge_arrays():
     for dt in ('uint64', 'int64', 'float64'):
         # needs plenty of memory
         a = np.arange(1e8, dtype=dt)
-        roundtrip_ndarray(a)
+        for case in roundtrip_ndarray(a):
+            yield case
 
 
 def test_alternate_cname():

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -264,3 +264,10 @@ def test_typesize_is_set_correctly_with_custom_blosc_args():
     pack_ndarray(a, sink, blosc_args=input_args)
     expected_args = BloscArgs(clevel=9, typesize=1)
     nt.assert_equal(expected_args, sink.blosc_args)
+
+
+def test_roundtrip_slice():
+    a = np.arange(100).reshape((10, 10))
+    s = a[3:5, 3:5]
+    for case in roundtrip_ndarray(s):
+        yield case

--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -3,9 +3,6 @@
 # vim :set ft=py:
 
 
-from unittest import TestCase
-
-
 import numpy as np
 import numpy.testing as npt
 import nose.tools as nt


### PR DESCRIPTION
I find a bug that can be revealed by the following code:

```python
x = np.random.random(100).reshape((10,10))

x_partial = x[3:5,3:5]
print 'x_original'
print x_partial

x_decoded = bp.unpack_ndarray_str(bp.pack_ndarray_str(x_partial))
print 'x_decoded'
print x_decoded
```

Two output array are different while they are expected to be identical.
```python
x_original
[[ 0.25004295  0.79043278]
 [ 0.01996618  0.15024981]]
x_decoded
[[ 0.25004295  0.79043278]
 [ 0.15371573  0.20340801]]
```

While if I copy the partial array, the result is correct. 
`x_decoded = bp.unpack_ndarray_str(bp.pack_ndarray_str(x_partial.copy()))`
