### PR TITLE
Conda recipe for bloscpack

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,75 @@
+package:
+  name: bloscpack
+  version: "0.10.0"
+
+source:
+  path: ../
+#  fn: bloscpack-0.10.0.tar.gz
+#  url: https://pypi.python.org/packages/68/d4/b47594bb8840e42fb257c392f2e1f177df68ee4e00a8e1a3e9ae7dc761b4/bloscpack-0.10.0.tar.gz
+#  md5: 967927ac01bb6d9fdd74b3ac02954b7f
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - bloscpack = bloscpack:main
+    #
+    # Would create an entry point called bloscpack that calls bloscpack.main()
+
+    - blpk = bloscpack.cli:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - blosc ==1.2.7
+    - numpy
+    - six
+
+  run:
+    - python
+    - blosc ==1.2.7
+    - numpy
+    - six
+
+test:
+  # Python imports
+  imports:
+    - bloscpack
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - blpk --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  requires:
+    - coverage
+#    - coveralls
+    - cram >=0.6
+    - mock
+    - nose
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/blosc/bloscpack
+  license: MIT License
+  summary: 'Command line interface to and serialization format for Blosc'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
recipe requires cram conda package (`-c ijstokes` conda channel) and currently comments out `coveralls` -- but otherwise builds