### PR TITLE
Esc/feature/print codec on info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,8 +263,17 @@ If you just need some info on how the file was compressed ``[i | info]``:
     blpk: [134320,459218,735869,986505,1237646,...]
     blpk: First chunk blosc header:
     blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 324894)])
-    blpk: First chunk blosc flags: 
+    blpk: First chunk blosc flags:
     blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
+
+Importantly, the header and flag information are for the first chunk only.
+Usually this isn't a problem because bloscpack compressed files do tend to have
+homogeneous settings like codec used, typesize etc... However, there is nothing
+that will stop you from appending to an existing bloscpack file using different
+settings. For example, half the file might be compressed using 'blosclz'
+whereas the other half of the file might be compressed with 'lz4'. In any case,
+just be aware that the output is to be seen as an indication that is likely to
+be correct for all chunks but must not be so necessarily.
 
 Adding Metdata
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -255,12 +255,16 @@ If you just need some info on how the file was compressed ``[i | info]``:
     blpk:     metadata: False
     blpk:     checksum: 'adler32'
     blpk:     typesize: 8
-    blpk:     chunk_size: 512.0M (536870912B)
-    blpk:     last_chunk: 501.88M (526258176B)
-    blpk:     nchunks: 3
-    blpk:     max_app_chunks: 30
+    blpk:     chunk_size: 1.0M (1048576B)
+    blpk:     last_chunk: 900.0K (921600B)
+    blpk:     nchunks: 1526
+    blpk:     max_app_chunks: 15260
     blpk: 'offsets':
-    blpk: [296,78074317,140782616,...]
+    blpk: [134320,459218,735869,986505,1237646,...]
+    blpk: First chunk blosc header:
+    blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 324894)])
+    blpk: First chunk blosc flags: 
+    blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
 
 Adding Metdata
 ~~~~~~~~~~~~~~

--- a/bloscpack/file_io.py
+++ b/bloscpack/file_io.py
@@ -315,6 +315,8 @@ def _read_compressed_chunk_fp(input_fp, checksum_impl):
         the compressed data
     blosc_header : dict
         the blosc header from the chunk
+    digest : str
+        the checksum of the chunk
     """
     # read blosc header
     blosc_header_raw = input_fp.read(BLOSC_HEADER_LENGTH)

--- a/test_cmdline/test_codec.cram
+++ b/test_cmdline/test_codec.cram
@@ -85,6 +85,10 @@ Try using an alternative codec ('lz4' should be available):
   blpk:     max_app_chunks: 1530
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
+  blpk: First chunk blosc header:
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 49), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 174045)])
+  blpk: First chunk blosc flags: 
+  blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', True), ('codec', 'lz4')])
   $ rm data.dat.blp
 
 Try using an  codec that is not available:

--- a/test_cmdline/test_info.cram
+++ b/test_cmdline/test_info.cram
@@ -29,6 +29,10 @@ Get some info on the file:
   blpk:     max_app_chunks: 1530
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
+  blpk: First chunk blosc header:
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 248901)])
+  blpk: First chunk blosc flags: 
+  blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ blpk i data.dat.blp
   blpk: BloscpackHeader:
   blpk:     format_version: 3
@@ -42,6 +46,10 @@ Get some info on the file:
   blpk:     max_app_chunks: 1530
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
+  blpk: First chunk blosc header:
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 248901)])
+  blpk: First chunk blosc flags: 
+  blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ rm data.dat.blp
   $ blpk info data.dat.blp
   blpk: error: file 'data.dat.blp' does not exist!

--- a/test_cmdline/test_metadata.cram
+++ b/test_cmdline/test_metadata.cram
@@ -38,6 +38,10 @@ Add metadata to the file:
   blpk:     max_meta_size: 680.0B (680B)
   blpk:     meta_comp_size: 6[2-5]\.0B \(6[2-5]B\) (re)
   blpk:     user_codec: b?'' (re)
+  blpk: First chunk blosc header:
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 131072), ('ctbytes', 248901)])
+  blpk: First chunk blosc flags: 
+  blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ blpk decompress data.dat.blp data.dat.dcmp
   blpk: Metadata:
   blpk: {u?'container': u?'numpy', u?'dtype': u?"'<f8'", u?'order': u?'C', u?'shape': \[20000000\]} (re)


### PR DESCRIPTION
this prints the basic chunk header info of the first chunk, when using info subcommand.

Fixed #8 