### PR TITLE
open README wit encoding given

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@
 
 from setuptools import setup
 import sys
+import io
 
-with open('README.rst', encoding='utf-8') as f:
+with io.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 with open('bloscpack/version.py') as f:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 import sys
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 with open('bloscpack/version.py') as f:


### PR DESCRIPTION
This is needed to build in non-UTF8 environments, like used for Debian builds.