### PR TITLE
remove tests that fail when typesize == 4

### DIFF
--- a/test/test_numpy_io.py
+++ b/test/test_numpy_io.py
@@ -215,7 +215,7 @@ def test_backwards_compat():
 def test_itemsize_chunk_size_mismatch():
     a = np.arange(1000)
     # typesize of the array is 8, let's glitch the typesize
-    for i in [1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15]:
+    for i in [1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15]:
             yield nt.assert_raises, \
                 ChunkSizeTypeSizeMismatch, \
                 pack_ndarray_to_bytes, a, i


### PR DESCRIPTION
On some architectures, such as i386, the default type size of
numpy.arange is float, which has an itemsize of 4. Remove the test cases
that would fail if the chunksize is divisible by 4 (in addition to 8 and
16).