### PR TITLE
MutableMapping has moved from collections to collections.abc

### DIFF
--- a/bloscpack/abstract_objects.py
+++ b/bloscpack/abstract_objects.py
@@ -13,7 +13,7 @@ from .pretty import (double_pretty_size,
                      )
 
 
-class MutableMappingObject(collections.MutableMapping):
+class MutableMappingObject(collections.abc.MutableMapping):
 
     _metaclass__ = abc.ABCMeta
 


### PR DESCRIPTION
The collection aliases have been deprecated since Python 3.3 and are going to be removed in 3.10.