### PR TITLE
make cmdline tests more resilient

### DIFF
--- a/test_cmdline/test_codec.cram
+++ b/test_cmdline/test_codec.cram
@@ -86,7 +86,7 @@ Try using an alternative codec ('lz4' should be available):
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
   blpk: First chunk blosc header:
-  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 33), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 524288), ('ctbytes', 134215)])
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 33), ('typesize', 8), ('nbytes', 1048576), ('blocksize', *), ('ctbytes', *)]) (glob)
   blpk: First chunk blosc flags: 
   blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'lz4')])
   $ rm data.dat.blp

--- a/test_cmdline/test_info.cram
+++ b/test_cmdline/test_info.cram
@@ -30,7 +30,7 @@ Get some info on the file:
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
   blpk: First chunk blosc header:
-  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 524288), ('ctbytes', 366674)])
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', *), ('ctbytes', *)]) (glob)
   blpk: First chunk blosc flags: 
   blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ blpk i data.dat.blp
@@ -47,7 +47,7 @@ Get some info on the file:
   blpk: 'offsets':
   blpk: \[13496,[1-9]\d*,[1-9]\d*,[1-9]\d*,[1-9]\d*,...\] (re)
   blpk: First chunk blosc header:
-  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 524288), ('ctbytes', 366674)])
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', *), ('ctbytes', *)]) (glob)
   blpk: First chunk blosc flags: 
   blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ rm data.dat.blp

--- a/test_cmdline/test_metadata.cram
+++ b/test_cmdline/test_metadata.cram
@@ -39,7 +39,7 @@ Add metadata to the file:
   blpk:     meta_comp_size: 6[2-5]\.0B \(6[2-5]B\) (re)
   blpk:     user_codec: b?'' (re)
   blpk: First chunk blosc header:
-  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', 524288), ('ctbytes', 366674)])
+  blpk: OrderedDict([('version', 2), ('versionlz', 1), ('flags', 1), ('typesize', 8), ('nbytes', 1048576), ('blocksize', *), ('ctbytes', *)]) (glob)
   blpk: First chunk blosc flags: 
   blpk: OrderedDict([('byte_shuffle', True), ('pure_memcpy', False), ('bit_shuffle', False), ('split_blocks', False), ('codec', 'blosclz')])
   $ blpk decompress data.dat.blp data.dat.dcmp

--- a/test_cmdline/test_verbose_debug.cram
+++ b/test_cmdline/test_verbose_debug.cram
@@ -150,7 +150,7 @@ Try using --debug
   blpk: reading bloscpack header
   blpk: bloscpack_header_raw: b?'.*' (re)
   blpk: bloscpack header: BloscpackHeader(format_version=3, offsets=True, metadata=False, checksum='adler32', typesize=8, chunk_size=52428800, last_chunk=2713600, nchunks=4, max_app_chunks=40)
-  blpk: Read raw offsets: b?'.*' (re)
+  blpk: Read raw offsets: b?.* (re)
   blpk: Offsets: \[384, [1-9]\d*, [1-9]\d*, [1-9]\d*\] (re)
   blpk: blosc_header: OrderedDict\(\[\('version', 2\), \('versionlz', 1\), \('flags', 1\), \('typesize', 8\), \('nbytes', 52428800\), \('blocksize', [1-9]\d*\), \('ctbytes', [1-9]\d*\)\]\) (re)
   blpk: decompressing chunk '0'
@@ -284,7 +284,7 @@ Try using --debug with metadata:
   blpk:     user_codec: b?'' (re)
   blpk: metadata checksum OK \(adler32\): b?'.*' (re)
   blpk: read compressed metadata of size: '6[2-5]' (re)
-  blpk: Read raw offsets: b?'.*' (re)
+  blpk: Read raw offsets: b?.* (re)
   blpk: Offsets: \[1100, [1-9]\d*, [1-9]\d*, [1-9]\d*\] (re)
   blpk: blosc_header: OrderedDict\(\[\('version', 2\), \('versionlz', 1\), \('flags', 1\), \('typesize', 8\), \('nbytes', 52428800\), \('blocksize', [1-9]\d*\), \('ctbytes', [1-9]\d*\)\]\) (re)
   blpk: decompressing chunk '0'


### PR DESCRIPTION
As the internals of the blosc library change, this kept breaking the
command line tests since these had certain values, like blocksize,
hardcoded. We replace these dependent values with globs to provide
greater test stability.