### PR TITLE
Fix running pytest with coverage

### DIFF
--- a/.github/workflows/testbloscpack.yml
+++ b/.github/workflows/testbloscpack.yml
@@ -21,8 +21,6 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r test_requirements.txt
-    - name: Install from source
-      run: pip install .
     - name: Run tests
       run: ./test.sh
     - name: Report coverage

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ echo "Testing command line interface with cram"
 COVERAGE=1 cram --verbose $@  test_cmdline/*.cram
 cram_exit=$?
 echo "Executing unit tests with pytest"
-pytest --cov=bloscpack test
+PYTHONPATH=. pytest --cov=bloscpack test
 pytest_exit=$?
 if [ $cram_exit -gt 0 ] || [ $pytest_exit -gt 0 ] ; then
     echo "some tests failed"

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ echo "Testing command line interface with cram"
 COVERAGE=1 cram --verbose $@  test_cmdline/*.cram
 cram_exit=$?
 echo "Executing unit tests with pytest"
-PYTHONPATH=. pytest --cov=bloscpack test
+PYTHONPATH=. pytest --cov=bloscpack --cov-append test
 pytest_exit=$?
 if [ $cram_exit -gt 0 ] || [ $pytest_exit -gt 0 ] ; then
     echo "some tests failed"


### PR DESCRIPTION
Pytest and coverage would get confused for an unknown reason presumably
related to installed packages vs. packages in the current directory. Not
installing bloscpack and running pytest with PYTHONPATH=. fixes this
issue.