### PR TITLE
Drop python2 support

### DIFF
--- a/bloscpack/args.py
+++ b/bloscpack/args.py
@@ -4,7 +4,6 @@
 
 
 import blosc
-from six import integer_types, string_types
 
 
 from .abstract_objects import (MutableMappingObject,
@@ -182,7 +181,7 @@ def calculate_nchunks(in_file_size, chunk_size=DEFAULT_CHUNK_SIZE):
         return (1, 0, 0)
         log.verbose("Input was length zero, ignoring 'chunk_size'")
     # convert a human readable description to an int
-    if isinstance(chunk_size, string_types):
+    if isinstance(chunk_size, str):
         chunk_size = reverse_pretty(chunk_size)
     check_range('chunk_size', chunk_size, 1, blosc.BLOSC_MAX_BUFFERSIZE)
     # downcast
@@ -265,7 +264,7 @@ def _handle_max_apps(offsets, nchunks, max_app_chunks):
             # it's a callable all right
             log.debug("max_app_chunks is a callable")
             max_app_chunks = max_app_chunks(nchunks)
-            if not isinstance(max_app_chunks, integer_types):
+            if not isinstance(max_app_chunks, int):
                 raise ValueError(
                         "max_app_chunks callable returned a non integer "
                         "of type '%s'" % type(max_app_chunks))
@@ -273,7 +272,7 @@ def _handle_max_apps(offsets, nchunks, max_app_chunks):
             if max_app_chunks < 0:
                 raise ValueError(
                         'max_app_chunks callable returned a negative integer')
-        elif isinstance(max_app_chunks, integer_types):
+        elif isinstance(max_app_chunks, int):
             # it's a plain int, check its range
             log.debug("max_app_chunks is an int")
             check_range('max_app_chunks', max_app_chunks, 0, MAX_CHUNKS)
@@ -426,7 +425,7 @@ class MetadataArgs(MutableMappingObject):
     def effective_max_meta_size(self, meta_size):
         if hasattr(self.max_meta_size, '__call__'):
             max_meta_size = self.max_meta_size(meta_size)
-        elif isinstance(self.max_meta_size, integer_types):
+        elif isinstance(self.max_meta_size, int):
             max_meta_size = self.max_meta_size
         log.debug('max meta size is deemed to be: %d' % max_meta_size)
         return max_meta_size

--- a/bloscpack/file_io.py
+++ b/bloscpack/file_io.py
@@ -9,8 +9,6 @@ import itertools
 import os.path as path
 
 import blosc
-import six
-from six.moves import xrange
 from deprecated import deprecated
 
 
@@ -87,7 +85,7 @@ def _write_metadata(output_fp, metadata, metadata_args):
     serializer_impl = SERIALIZERS_LOOKUP[metadata_args.magic_format]
     metadata = serializer_impl.dumps(metadata)
     meta_size = len(metadata)
-    if six.PY3 and isinstance(metadata, str):
+    if isinstance(metadata, str):
         metadata = metadata.encode()
     if metadata_args.should_compress:
         codec_impl = metadata_args.meta_codec_impl
@@ -129,7 +127,7 @@ def _write_metadata(output_fp, metadata, metadata_args):
     output_fp.write(raw_metadata_header)
     output_fp.write(metadata)
     prealloc = max_meta_size - meta_comp_size
-    for i in xrange(prealloc):
+    for i in range(prealloc):
         output_fp.write(b'\x00')
     metadata_total += prealloc
     log.debug("metadata has %d preallocated empty bytes" % prealloc)
@@ -228,7 +226,7 @@ def _read_metadata(input_fp):
             ('compressed' if metadata_header.meta_codec != 'None' else
                 'uncompressed', metadata_header.meta_comp_size))
     serializer_impl = SERIALIZERS_LOOKUP[metadata_header.magic_format]
-    if six.PY3 and isinstance(metadata, bytes):
+    if isinstance(metadata, bytes):
         metadata = metadata.decode()
     metadata = serializer_impl.loads(metadata)
     return metadata, metadata_header
@@ -258,7 +256,7 @@ def _read_offsets(input_fp, bloscpack_header):
         offsets_raw = input_fp.read(8 * total_entries)
         log.debug('Read raw offsets: %s' % repr(offsets_raw))
         offsets = [decode_int64(offsets_raw[j - 8:j]) for j in
-                   xrange(8, bloscpack_header.nchunks * 8 + 1, 8)]
+                   range(8, bloscpack_header.nchunks * 8 + 1, 8)]
         log.debug('Offsets: %s' % offsets)
         return offsets
     else:
@@ -364,7 +362,7 @@ class CompressedFPSource(CompressedSource):
         self.nchunks = self.bloscpack_header.nchunks
 
     def __iter__(self):
-        for i in xrange(self.nchunks):
+        for i in range(self.nchunks):
             compressed, header, digest = _read_compressed_chunk_fp(self.input_fp, self.checksum_impl)
             yield compressed, digest
 

--- a/bloscpack/headers.py
+++ b/bloscpack/headers.py
@@ -12,7 +12,6 @@ except ImportError:
 
 
 import blosc
-from six import PY3, integer_types, binary_type
 
 from .abstract_objects import (MutableMappingObject,
                                )
@@ -41,7 +40,7 @@ from . import log
 
 def check_range(name, value, min_, max_):
     """ Check that a variable is in range. """
-    if not isinstance(value, integer_types):
+    if not isinstance(value, int):
         raise TypeError("'%s' must be of type 'int'" % name)
     elif not min_ <= value <= max_:
         raise ValueError(
@@ -50,7 +49,7 @@ def check_range(name, value, min_, max_):
 
 
 def _check_str(name, value, max_len):
-    if not isinstance(value, binary_type):
+    if not isinstance(value, bytes):
         raise TypeError("'%s' must be of type 'str'/'bytes'" % name)
     elif len(value) > max_len:
         raise ValueError("'%s' can be of max length '%i' but is: '%s'" %
@@ -104,10 +103,7 @@ def check_options_zero(options, indices):
 
 
 def decode_uint8(byte):
-    if PY3:
-        return byte
-    else:
-        return struct.unpack('<B', byte)[0]
+    return byte
 
 
 def decode_uint32(fourbyte):
@@ -127,10 +123,7 @@ def decode_bitfield(byte):
 
 
 def decode_magic_string(str_):
-    if PY3:
-        return str_.strip(b'\x00')
-    else:
-        return str_.strip('\x00')
+    return str_.strip(b'\x00')
 
 
 def encode_uint8(byte):

--- a/bloscpack/memory_io.py
+++ b/bloscpack/memory_io.py
@@ -3,7 +3,6 @@
 # vim :set ft=py:
 
 import blosc
-from six.moves import xrange
 
 from .abstract_io import (PlainSource,
                           CompressedSource,
@@ -39,7 +38,7 @@ class CompressedMemorySource(CompressedSource):
             self.checksums = compressed_memory_sink.checksums
 
     def __iter__(self):
-        for i in xrange(self.nchunks):
+        for i in range(self.nchunks):
             compressed = self.chunks[i]
             digest = self.checksums[i] if self.checksum else None
             yield compressed, digest

--- a/bloscpack/numpy_io.py
+++ b/bloscpack/numpy_io.py
@@ -7,8 +7,6 @@ import ast
 
 import blosc
 import numpy
-import six
-from six.moves import xrange
 from deprecated import deprecated
 
 
@@ -89,7 +87,7 @@ class PlainNumpySource(PlainSource):
                 )
         self.nitems = int(self.chunk_size / self.ndarray.itemsize)
         offset = self.ptr
-        for i in xrange(self.nchunks - 1):
+        for i in range(self.nchunks - 1):
             yield offset, self.nitems
             offset += self.chunk_size
         yield offset, int(self.last_chunk / self.ndarray.itemsize)
@@ -112,8 +110,6 @@ def _conv(descr):
             descr = [_conv(d) for d in descr]
         else:
             descr = tuple([_conv(d) for d in descr])
-    elif six.PY2 and isinstance(descr, unicode):  # pragma: no cover
-        descr = str(descr)
     return descr
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 blosc
 numpy
-six
 deprecated


### PR DESCRIPTION
Python 2 went EOL on 1/1/2020 and we receive no more support from the Python Core Team after Python 2.7.18 even for known security issues.